### PR TITLE
Rename hugging-face organization (backward compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Check [Novae's documentation](https://prism-oncology.github.io/novae/) to get st
   <img src="https://raw.githubusercontent.com/prism-oncology/novae/main/docs/assets/Figure1.png" alt="novae_overview" width="100%"/>
 </p>
 
-> **(a)** Novae was trained on a large dataset, and is shared on [Hugging Face Hub](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd). **(b)** Illustration of the main tasks and properties of Novae. **(c)** Illustration of the method behind Novae (self-supervision on graphs, adapted from [SwAV](https://arxiv.org/abs/2006.09882)).
+> **(a)** Novae was trained on a large dataset, and is shared on [Hugging Face Hub](https://huggingface.co/collections/prism-oncology/novae). **(b)** Illustration of the main tasks and properties of Novae. **(c)** Illustration of the method behind Novae (self-supervision on graphs, adapted from [SwAV](https://arxiv.org/abs/2006.09882)).
 
 ## Installation
 
@@ -58,7 +58,7 @@ import novae
 novae.spatial_neighbors(adata)
 
 # load a pre-trained model
-model = novae.Novae.from_pretrained("MICS-Lab/novae-human-0")
+model = novae.Novae.from_pretrained("prism-oncology/novae-human-0")
 
 # compute spatial domains
 model.compute_representations(adata, zero_shot=True)

--- a/data/README.md
+++ b/data/README.md
@@ -4,7 +4,7 @@ We detail below how to download the datasets used in our article.
 
 ## Option 1: via Hugging Face Hub (recommended)
 
-We store our dataset on [Hugging Face Hub](https://huggingface.co/datasets/MICS-Lab/novae).
+We store our dataset on [Hugging Face Hub](https://huggingface.co/datasets/prism-oncology/novae).
 
 To automatically download these slides, you can use the [`novae.load_dataset`](https://prism-oncology.github.io/novae/api/data/#novae.load_dataset) function.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,12 +12,12 @@ For more details, refer to the API of the [PyTorch Lightning Trainer](https://li
 
 ### How to load a pretrained model?
 
-We highly recommend loading a pre-trained Novae model instead of re-training from scratch. For that, choose an available Novae model name on [our HuggingFace collection](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd), and provide this name to the [model.save_pretrained()](../api/Novae/#novae.Novae.save_pretrained) method:
+We highly recommend loading a pre-trained Novae model instead of re-training from scratch. For that, choose an available Novae model name on [our HuggingFace collection](https://huggingface.co/collections/prism-oncology/novae), and provide this name to the [model.save_pretrained()](../api/Novae/#novae.Novae.save_pretrained) method:
 
 ```python
 from novae import Novae
 
-model = Novae.from_pretrained("MICS-Lab/novae-human-0") # or any valid model name
+model = Novae.from_pretrained("prism-oncology/novae-human-0") # or any valid model name
 ```
 
 ### How to avoid overcorrecting?

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Novae is a deep learning model for spatial domain assignments of spatial transcr
   <img src="https://raw.githubusercontent.com/prism-oncology/novae/main/docs/assets/Figure1.png" alt="novae_overview" width="100%"/>
 </p>
 
-> **(a)** Novae was trained on a large dataset, and is shared on [Hugging Face Hub](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd). **(b)** Illustration of the main tasks and properties of Novae. **(c)** Illustration of the method behind Novae (self-supervision on graphs, adapted from [SwAV](https://arxiv.org/abs/2006.09882)).
+> **(a)** Novae was trained on a large dataset, and is shared on [Hugging Face Hub](https://huggingface.co/collections/prism-oncology/novae). **(b)** Illustration of the main tasks and properties of Novae. **(c)** Illustration of the method behind Novae (self-supervision on graphs, adapted from [SwAV](https://arxiv.org/abs/2006.09882)).
 
 
 ## Why using Novae

--- a/docs/tutorials/main_usage.ipynb
+++ b/docs/tutorials/main_usage.ipynb
@@ -153,12 +153,12 @@
         "\n",
         "Now, we need to load a pretrained Novae model.\n",
         "\n",
-        "Since we have a human colon slide, we load the `\"MICS-Lab/novae-human-0\"` model, which can be used on any human tissue for spatial data with single-cell resolution. Other model names can be found [here](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd) (spot-resolution models, e.g., for Visium data, will come soon).\n"
+        "Since we have a human colon slide, we load the `\"prism-oncology/novae-human-0\"` model, which can be used on any human tissue for spatial data with single-cell resolution. Other model names can be found [here](https://huggingface.co/collections/prism-oncology/novae) (spot-resolution models, e.g., for Visium data, will come soon).\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [
         {
@@ -166,17 +166,19 @@
             "text/plain": [
               "Novae model\n",
               "   ├── Known genes: 60697\n",
-              "   ├── Parameters: 32.0M\n",
-              "   └── Model name: MICS-Lab/novae-human-0"
+              "   ├── Parameters: 32.1M\n",
+              "   ├── Model name: prism-oncology/novae-human-0\n",
+              "   ├── Trained: True\n",
+              "   └── Multimodal: False"
             ]
           },
-          "execution_count": 7,
+          "execution_count": 3,
           "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
-        "model = novae.Novae.from_pretrained(\"MICS-Lab/novae-human-0\")\n",
+        "model = novae.Novae.from_pretrained(\"prism-oncology/novae-human-0\")\n",
         "model"
       ]
     },
@@ -448,12 +450,12 @@
       "source": [
         "Since we are now working on mouse brain data, we'll load the brain model, as shown below.\n",
         "\n",
-        "Reminder: for human tissues, you can use the `\"MICS-Lab/novae-human-0\"` model. Again, other model names can be found [here](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd).\n"
+        "> ℹ️ Reminder: for human tissues, you can use the `\"prism-oncology/novae-human-0\"` model. As stated above, other model names can be found [here](https://huggingface.co/collections/prism-oncology/novae).\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 71,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -461,17 +463,19 @@
             "text/plain": [
               "Novae model\n",
               "   ├── Known genes: 60697\n",
-              "   ├── Parameters: 32.0M\n",
-              "   └── Model name: MICS-Lab/novae-brain-0"
+              "   ├── Parameters: 32.1M\n",
+              "   ├── Model name: prism-oncology/novae-brain-0\n",
+              "   ├── Trained: True\n",
+              "   └── Multimodal: False"
             ]
           },
-          "execution_count": 71,
+          "execution_count": 8,
           "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
-        "model = novae.Novae.from_pretrained(\"MICS-Lab/novae-brain-0\")\n",
+        "model = novae.Novae.from_pretrained(\"prism-oncology/novae-brain-0\")\n",
         "model"
       ]
     },

--- a/docs/tutorials/main_usage.ipynb
+++ b/docs/tutorials/main_usage.ipynb
@@ -153,7 +153,9 @@
         "\n",
         "Now, we need to load a pretrained Novae model.\n",
         "\n",
-        "Since we have a human colon slide, we load the `\"prism-oncology/novae-human-0\"` model, which can be used on any human tissue for spatial data with single-cell resolution. Other model names can be found [here](https://huggingface.co/collections/prism-oncology/novae) (spot-resolution models, e.g., for Visium data, will come soon).\n"
+        "Since we have a human colon slide, we load the `\"prism-oncology/novae-human-0\"` model, which can be used on any human tissue for spatial data with single-cell resolution. Other model names can be found [here](https://huggingface.co/collections/prism-oncology/novae) (spot-resolution models, e.g., for Visium data, will come soon).\n",
+        "\n",
+        "> ⚠️ If you have `novae<1.0.5`, you'll not be able to load `prism-oncology/novae-human-0`, as we renamed recently our Hugging Face organization. Either upgrade novae, or use `MICS-Lab/novae-human-0` instead.\n"
       ]
     },
     {

--- a/novae/data/_load/_hf.py
+++ b/novae/data/_load/_hf.py
@@ -15,13 +15,13 @@ def _read_h5ad_from_hub(name: str, row: pd.Series, annotations: bool = False) ->
     from huggingface_hub import hf_hub_download
 
     file_path = f"{row['species']}/{row['tissue']}/{name}.h5ad"
-    local_file = hf_hub_download(repo_id="MICS-Lab/novae", filename=file_path, repo_type="dataset")
+    local_file = hf_hub_download(repo_id="prism-oncology/novae", filename=file_path, repo_type="dataset")
 
     adata = sc.read_h5ad(local_file)
 
     if annotations:
         try:
-            df_annot = pd.read_parquet(f"hf://datasets/MICS-Lab/novae/annotations/{name}.parquet")
+            df_annot = pd.read_parquet(f"hf://datasets/prism-oncology/novae/annotations/{name}.parquet")
             adata.obs[df_annot.columns] = df_annot
         except FileNotFoundError:
             log.warning(f"Annotations unavailable for {name}. They will not be added to the adata.obs.")
@@ -45,7 +45,7 @@ def load_dataset(
 
     !!! info "Selecting slides"
         The function arguments allow to filter the slides based on the tissue, species, and name pattern.
-        Internally, the function reads [this dataset metadata file](https://huggingface.co/datasets/MICS-Lab/novae/blob/main/metadata.csv) to select the slides that match the provided filters.
+        Internally, the function reads [this dataset metadata file](https://huggingface.co/datasets/prism-oncology/novae/blob/main/metadata.csv) to select the slides that match the provided filters.
 
     Args:
         pattern: Optional pattern to match the slides names, or directly a slide name.
@@ -60,7 +60,7 @@ def load_dataset(
     Returns:
         A list of `AnnData` objects, each object corresponds to one slide, or the metadata DataFrame if `dry_run=True`.
     """
-    metadata = pd.read_csv("hf://datasets/MICS-Lab/novae/metadata.csv", index_col=0)
+    metadata = pd.read_csv("hf://datasets/prism-oncology/novae/metadata.csv", index_col=0)
 
     FILTER_COLUMN = [("species", species), ("tissue", tissue), ("technology", technology)]
     VALID_VALUES = {column: metadata[column].unique() for column, _ in FILTER_COLUMN}

--- a/novae/model.py
+++ b/novae/model.py
@@ -32,7 +32,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
 
         novae.spatial_neighbors(adata)
 
-        model = novae.Novae.from_pretrained("MICS-Lab/novae-human-0")
+        model = novae.Novae.from_pretrained("prism-oncology/novae-human-0")
 
         model.compute_representations(adata, zero_shot=True)
         model.assign_domains(adata)
@@ -298,10 +298,10 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
         """Load a pretrained `Novae` model from HuggingFace Hub.
 
         !!! info "Available model names"
-            See [here](https://huggingface.co/collections/MICS-Lab/novae-669cdf1754729d168a69f6bd) the available Novae model names.
+            See [here](https://huggingface.co/collections/prism-oncology/novae-669cdf1754729d168a69f6bd) the available Novae model names.
 
         Args:
-            model_name_or_path: Name of the model, e.g. `"MICS-Lab/novae-human-0"`, or path to the local model.
+            model_name_or_path: Name of the model, e.g. `"prism-oncology/novae-human-0"`, or path to the local model.
             **kwargs: Optional kwargs for Hugging Face [`from_pretrained`](https://huggingface.co/docs/huggingface_hub/v0.24.0/en/package_reference/mixins#huggingface_hub.ModelHubMixin.from_pretrained) method.
 
         Returns:

--- a/novae/utils/_validate.py
+++ b/novae/utils/_validate.py
@@ -282,18 +282,18 @@ def check_slide_name_key(adatas: AnnData | list[AnnData], slide_name_key: str | 
     return slide_name_key
 
 
-OLD_ORGANIZATION = "MICS-Lab"
-ORGANIZATION = "prism-oncology"
+OLD_ORGANIZATION = "MICS-Lab/"
+ORGANIZATION = "prism-oncology/"
 
 
 def check_model_name(model_name: str | Path) -> None:
-    if model_name in [f"{OLD_ORGANIZATION}/novae-test", f"{ORGANIZATION}/novae-test"]:
+    if model_name in [f"{OLD_ORGANIZATION}novae-test", f"{ORGANIZATION}novae-test"]:
         return
 
     if not str(model_name).startswith(OLD_ORGANIZATION) and not str(model_name).startswith(ORGANIZATION):  # local path
         if not Path(model_name).exists():
             raise ValueError(
-                f"Model name or path '{model_name}' not found locally. Please provide a valid local path, or use a model from Hugging Face Hub (e.g., starting with 'MICS-Lab')."
+                f"Model name or path '{model_name}' not found locally. Please provide a valid local path, or use a model from Hugging Face Hub (see https://huggingface.co/collections/prism-oncology/novae)."
             )
     else:
         assert isinstance(model_name, str), "Model name must be a string when loading from Hugging Face Hub"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -43,14 +43,16 @@ _generate_fake_scgpt_inputs()
 
 
 def test_load_huggingface_model():
-    model = novae.Novae.from_pretrained("MICS-Lab/novae-test")
+    model = novae.Novae.from_pretrained("MICS-Lab/novae-test")  # should still work with old name
+    assert model.cell_embedder.embedding.weight.requires_grad is False
 
+    model = novae.Novae.from_pretrained("prism-oncology/novae-test")
     assert model.cell_embedder.embedding.weight.requires_grad is False
 
 
 def test_future_huggingface_model():
     with pytest.raises(ValueError):
-        novae.Novae.from_pretrained("MICS-Lab/novae-human-3")
+        novae.Novae.from_pretrained("prism-oncology/novae-human-3")
 
 
 def test_non_existing_local_model():
@@ -245,7 +247,7 @@ def test_saved_model_identical(slide_key: str | None, scgpt_model_dir: str | Non
 def test_fine_tuning_deterministic():
     adata = novae.toy_dataset(n_panels=1, compute_spatial_neighbors=True, xmax=300)[0]
 
-    model = novae.Novae.from_pretrained("MICS-Lab/novae-human-0")
+    model = novae.Novae.from_pretrained("prism-oncology/novae-human-0")
     L.seed_everything(0)
     model.fine_tune(adata, max_epochs=1)
     model.compute_representations(adata)
@@ -254,7 +256,7 @@ def test_fine_tuning_deterministic():
     domains = adata.obs[Keys.LEAVES].copy()
     representations = adata.obsm[Keys.REPR].copy()
 
-    new_model = novae.Novae.from_pretrained("MICS-Lab/novae-human-0")
+    new_model = novae.Novae.from_pretrained("prism-oncology/novae-human-0")
     L.seed_everything(0)
     new_model.fine_tune(adata, max_epochs=1)
     new_model.compute_representations(adata)
@@ -268,7 +270,7 @@ def test_safetensors_parameters_names():
     from huggingface_hub import hf_hub_download
     from safetensors import safe_open
 
-    local_file = hf_hub_download(repo_id="MICS-Lab/novae-human-0", filename="model.safetensors")
+    local_file = hf_hub_download(repo_id="prism-oncology/novae-human-0", filename="model.safetensors")
     with safe_open(local_file, framework="pt", device="cpu") as f:
         pretrained_model_names = f.keys()
 
@@ -276,7 +278,7 @@ def test_safetensors_parameters_names():
 
     actual_names = [name for name, _ in model.named_parameters()]
 
-    # TODO: remove this after MICS-Lab/novae-human-1 release (and update where it is loaded)
+    # TODO: remove this after prism-oncology/novae-human-1 release (and update where it is loaded)
     actual_names = [name for name in actual_names if not name.startswith("encoder.mlp_fusion")]
 
     assert set(pretrained_model_names) == set(actual_names)
@@ -287,7 +289,7 @@ def test_reset_clusters_zero_shot():
 
     novae.utils.spatial_neighbors(adata)
 
-    model = novae.Novae.from_pretrained("MICS-Lab/novae-human-0")
+    model = novae.Novae.from_pretrained("prism-oncology/novae-human-0")
 
     model.compute_representations(adata, zero_shot=True)
     clusters_levels = model.swav_head.clusters_levels.copy()


### PR DESCRIPTION
Moved huffing face organization from `MICS-Lab` to `prism-oncology`. See new org [here](https://huggingface.co/prism-oncology).

Loading a model from the previous organization name should still work (added to the tests).