### PR TITLE
Conserve zero-shot prototypes when re-computing representations

### DIFF
--- a/docs/advice.md
+++ b/docs/advice.md
@@ -6,7 +6,7 @@ Here, we list some advice to help you get the best out of Novae.
 When you have many slides, it's recommended to train or fine-tune Novae only on the good quality slides and run inference (i.e., spatial domain assignment) on all slides. This allows noise removal in the model training while still applying Novae to the low quality slides.
 
 ### Resolution or level
-When running [`assign_domains`](../api/Novae/#novae.Novae.assign_domains) in **zero-shot**, it's generally better to use the `resolution` argument. When fine-tuning or re-training a Novae model, using `level` is recommended.
+When running [`assign_domains`](../api/Novae/#novae.Novae.assign_domains) in **zero-shot**, it's generally better to use the `resolution` argument. When fine-tuning or re-training a Novae model, both `level` and `resolution` are recommended (depending whether you need hierarchies of domains).
 
 !!! info
     An advantage of using `level` is that the domains will be nested through the different levels — we don't have such a property using the `resolution` argument.
@@ -26,8 +26,15 @@ If you have a rare tissue or a tissue that was not used in our large dataset, yo
 ### Using references
 For the zero-shot and fine-tuning modes, you can provide a `reference` slide (or multiple slides). This allows to recompute the model prototypes (i.e., the centroids of the spatial domains) based on the chosen slides.
 
-- For [zero-shot](../api/Novae/#novae.Novae.compute_representations), we use `reference="all"` by default, meaning we use all slides to recompute the prototypes. Depending on your use case, you may consider specifying one or multiple **representative** slides.
+- For [zero-shot](../api/Novae/#novae.Novae.compute_representations), we use `reference="all"` by default, meaning we use all slides to recompute the prototypes. Depending on your use case, you may consider specifying one or multiple **representative** slides (see how to to that below).
 - For [fine-tuning](../api/Novae/#novae.Novae.fine_tune), we use `reference=None` by default, meaning we will initialize the prototypes randomly, and re-train them. If you have only one slide (or if you know what you're doing), it might be worth trying `reference="all"`, but we usually recommend sticking to the default value.
+
+!!! info
+    Other `reference` options include:
+
+    - `reference="largest"` to choose the slide with the highest number of cells.
+    - `reference="slide_name"` or `reference=["slide_name1", "slide_name2"]` to select slides by their novae-ID. If you provided a `slide_key` to [`novae.spatial_neighbors`](../api/utils/#novae.spatial_neighbors) then the ID is the one from your `slide_key`, else look at the slide ID in `adata.obs["novae_sid"]`.
+    - `reference=2` or `reference=[2, 3, 5]` to select slides by the index within the list of slides if you're using a `list[AnnData]`
 
 ### Handling large datasets
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,6 +87,12 @@ To force not using the multimodal mode although you already computed H&E embeddi
 novae.settings.disable_multimodal = True
 ```
 
+### Can I re-use a zero-shot model?
+Yes, since `novae==1.0.7`, you can save and re-load a novae model that was run in zero-shot, and the spatial-domains will be preserved. You can use it as a normal trained model (i.e., using `model.compute_representations(..., zero_shot=False)`).
+
+!!! info
+    As long as you don't fine-tune or re-run zero-shot, `assign_domains` will always return the same domain names.
+
 ### How long does it take to use Novae?
 
 The `pip` installation of Novae usually takes less than a minute on a standard laptop. The inference time depends on the number of cells, but typically takes 5-20 minutes on a CPUs, or 30sec to 2 minutes on a GPU (expect it to be roughly 10x times faster on a GPU).

--- a/novae/model.py
+++ b/novae/model.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 import lightning as L
 import numpy as np
-import scanpy as sc
 import torch
 from anndata import AnnData
 from huggingface_hub import PyTorchModelHubMixin
@@ -149,7 +148,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
             self._prepare_adatas(utils.get_reference(adata, reference)), sample_cells=Nums.DEFAULT_SAMPLE_CELLS
         )
         latent = self._compute_representations_datamodule(None, datamodule, return_representations=True)
-        self.swav_head._prototypes = self.swav_head.compute_kmeans_prototypes(latent)
+        self.swav_head.update_kmeans_prototypes(latent)
 
     def __repr__(self) -> str:
         info_dict: dict[str, int | str | bool | None] = {
@@ -280,7 +279,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
         self.datamodule.dataset.shuffle_obs_ilocs()
 
         after_warm_up = self.current_epoch >= Nums.WARMUP_EPOCHS
-        self.swav_head.prototypes.requires_grad_(after_warm_up or self.mode.pretrained)
+        self.swav_head._prototypes.requires_grad_(after_warm_up or self.mode.pretrained)
 
     def _log_progress_bar(self, name: str, value: float, on_epoch: bool = True, prog_bar: bool = True, **kwargs):
         self.log(
@@ -414,8 +413,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
         adatas_refs = [adatas_refs] if isinstance(adatas_refs, AnnData) else adatas_refs
 
         latent = np.concatenate([adata.obsm[Keys.REPR][utils.valid_indices(adata)] for adata in adatas_refs])
-        self.swav_head._kmeans_prototypes = self.swav_head.compute_kmeans_prototypes(latent)
-        self.swav_head.reset_clustering(only_zero_shot=True)
+        self.swav_head.update_kmeans_prototypes(latent)
 
         for adata in adatas:
             self._compute_leaves(adata, None, None)
@@ -512,7 +510,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
         plot._weights_clustermap(weights, self.adatas, list(self.swav_head.slide_label_encoder.keys()), **kwargs)
 
     def plot_prototype_covariance(self, vmax: float | None = None, **kwargs):
-        covariance = np.cov(self.swav_head.prototypes.data.numpy(force=True))
+        covariance = np.cov(self.swav_head._prototypes.data.numpy(force=True))
 
         vmax = vmax or covariance.max()
 
@@ -557,7 +555,7 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
         )
 
         if resolution is not None:
-            _leiden_codes = self._leiden_prototypes(resolution=resolution)
+            _leiden_codes = self.swav_head.leiden_clustering(resolution=resolution)
 
             key_added = f"{Keys.DOMAINS_PREFIX}res{resolution}"
 
@@ -585,18 +583,6 @@ class Novae(L.LightningModule, PyTorchModelHubMixin):
             adata.obs[key_added] = adata.obs[key_added].astype("category")
 
         return key_added
-
-    @torch.no_grad()
-    def _leiden_prototypes(self, resolution: float = 1, return_codes: bool = True) -> AnnData | np.ndarray:
-        adata_proto = AnnData(self.swav_head.prototypes.numpy(force=True))
-
-        sc.pp.pca(adata_proto)
-        sc.pp.neighbors(adata_proto)
-        sc.tl.leiden(adata_proto, flavor="igraph", resolution=resolution)
-
-        if return_codes:
-            return adata_proto.obs["leiden"].values.codes
-        return adata_proto
 
     def batch_effect_correction(self, adata: AnnData | list[AnnData] | None = None, obs_key: str | None = None):
         """Correct batch effects from the spatial representations of cells.

--- a/novae/module/swav.py
+++ b/novae/module/swav.py
@@ -4,8 +4,10 @@ import math
 import lightning as L
 import numpy as np
 import pandas as pd
+import scanpy as sc
 import torch
 import torch.nn.functional as F
+from anndata import AnnData
 from sklearn.cluster import AgglomerativeClustering, KMeans
 from torch import Tensor, nn
 
@@ -43,8 +45,6 @@ class SwavHead(L.LightningModule):
         self.normalize_prototypes()
         self.min_prototypes = 0
 
-        self._kmeans_prototypes: nn.Parameter | None = None
-
         self.queue = None
 
         self.reset_clustering()
@@ -71,7 +71,7 @@ class SwavHead(L.LightningModule):
 
     @torch.no_grad()
     def normalize_prototypes(self):
-        self.prototypes.data = F.normalize(self.prototypes.data, dim=1, p=2)
+        self._prototypes.data = F.normalize(self._prototypes.data, dim=1, p=2)
 
     def forward(self, z1: Tensor, z2: Tensor, slide_id: str | None) -> tuple[Tensor, Tensor]:
         """Compute the SwAV loss for two batches of neighborhood graph views.
@@ -112,7 +112,7 @@ class SwavHead(L.LightningModule):
             The projections of size `(B, K)`.
         """
         z_normalized = F.normalize(z, dim=1, p=2)
-        return z_normalized @ self.prototypes.T
+        return z_normalized @ self._prototypes.T
 
     @torch.no_grad()
     def prototype_ilocs(self, projections: Tensor, slide_id: str | None = None) -> Tensor:
@@ -184,7 +184,7 @@ class SwavHead(L.LightningModule):
 
         return Q / Q.sum(dim=1, keepdim=True)  # ensure rows sum to 1 (for cross-entropy loss)
 
-    def compute_kmeans_prototypes(self, latent: np.ndarray) -> nn.Parameter:
+    def update_kmeans_prototypes(self, latent: np.ndarray) -> None:
         assert len(latent) >= self.num_prototypes, (
             f"The number of valid cells ({len(latent)}) must be greater than the number of prototypes ({self.num_prototypes})."
         )
@@ -195,63 +195,58 @@ class SwavHead(L.LightningModule):
         kmeans_prototypes = kmeans.fit(X).cluster_centers_
         kmeans_prototypes = kmeans_prototypes / (Nums.EPS + np.linalg.norm(kmeans_prototypes, axis=1)[:, None])
 
-        return torch.nn.Parameter(torch.tensor(kmeans_prototypes))
+        self._prototypes = torch.nn.Parameter(torch.tensor(kmeans_prototypes))
 
-    @property
-    def prototypes(self) -> nn.Parameter:
-        return self._kmeans_prototypes if self.mode.zero_shot else self._prototypes
+        self.reset_clustering()
 
     @property
     def clustering(self) -> AgglomerativeClustering:
-        clustering_attr = self.mode.clustering_attr
-
-        if getattr(self, clustering_attr) is None:
+        if self._clustering is None:
             self.hierarchical_clustering()
-
-        return getattr(self, clustering_attr)
+        return self._clustering
 
     @property
     def clusters_levels(self) -> np.ndarray:
-        clusters_levels_attr = self.mode.clusters_levels_attr
-
-        if getattr(self, clusters_levels_attr) is None:
+        if self._clusters_levels is None:
             self.hierarchical_clustering()
+        return self._clusters_levels
 
-        return getattr(self, clusters_levels_attr)
-
-    def reset_clustering(self, only_zero_shot: bool = False) -> None:
-        attrs = self.mode.zero_shot_clustering_attrs if only_zero_shot else self.mode.all_clustering_attrs
-        for attr in attrs:
-            setattr(self, attr, None)
-
-    def set_clustering(self, clustering: None, clusters_levels: None) -> None:
-        setattr(self, self.mode.clustering_attr, clustering)
-        setattr(self, self.mode.clusters_levels_attr, clusters_levels)
+    def reset_clustering(self) -> None:
+        self._clustering = None
+        self._clusters_levels = None
 
     def hierarchical_clustering(self) -> None:
         """
         Perform hierarchical clustering on the prototypes. Saves the full tree of clusters.
         """
-        X = self.prototypes.data.numpy(force=True)  # (K, O)
+        X = self._prototypes.data.numpy(force=True)  # (K, O)
 
-        _clustering = AgglomerativeClustering(
+        self._clustering = AgglomerativeClustering(
             n_clusters=None,
             distance_threshold=0,
             compute_full_tree=True,
             metric="cosine",
             linkage="average",
         )
-        _clustering.fit(X)
+        self._clustering.fit(X)
 
-        _clusters_levels = np.zeros((len(X), len(X)), dtype=np.uint16)
-        _clusters_levels[0] = np.arange(len(X))
+        self._clusters_levels = np.zeros((len(X), len(X)), dtype=np.uint16)
+        self._clusters_levels[0] = np.arange(len(X))
 
-        for i, (a, b) in enumerate(_clustering.children_):
-            clusters = _clusters_levels[i]
-            _clusters_levels[i + 1] = clusters
-            _clusters_levels[i + 1, np.where((clusters == a) | (clusters == b))] = len(X) + i
+        for i, (a, b) in enumerate(self._clustering.children_):
+            clusters = self._clusters_levels[i]
+            self._clusters_levels[i + 1] = clusters
+            self._clusters_levels[i + 1, np.where((clusters == a) | (clusters == b))] = len(X) + i
 
-        self.set_clustering(_clustering, _clusters_levels)
+    @torch.no_grad()
+    def leiden_clustering(self, resolution: float = 1) -> np.ndarray:
+        adata_proto = AnnData(self._prototypes.numpy(force=True))
+
+        sc.pp.pca(adata_proto)
+        sc.pp.neighbors(adata_proto)
+        sc.tl.leiden(adata_proto, flavor="igraph", resolution=resolution)
+
+        return adata_proto.obs["leiden"].values.codes
 
     def map_leaves_domains(self, series: pd.Series, level: int) -> pd.Series:
         """Map leaves to the parent domain from the corresponding level of the hierarchical tree.

--- a/novae/monitor/callback.py
+++ b/novae/monitor/callback.py
@@ -14,7 +14,7 @@ from .log import log_plt_figure, save_pdf_figure
 
 class LogProtoCovCallback(Callback):
     def on_train_epoch_end(self, trainer: Trainer, model: Novae) -> None:
-        C = model.swav_head.prototypes.data.numpy(force=True)
+        C = model.swav_head._prototypes.data.numpy(force=True)
 
         plt.figure(figsize=(10, 10))
         sns.clustermap(np.cov(C))
@@ -99,7 +99,7 @@ class PrototypeUMAPCallback(Callback):
     LEVEL: int = 15
 
     def on_train_epoch_end(self, trainer: Trainer, model: Novae):
-        adata_proto = AnnData(model.swav_head.prototypes.data.numpy(force=True))
+        adata_proto = AnnData(model.swav_head._prototypes.data.numpy(force=True))
 
         sc.pp.neighbors(adata_proto)
         sc.tl.umap(adata_proto)

--- a/novae/utils/mode.py
+++ b/novae/utils/mode.py
@@ -1,10 +1,6 @@
 class Mode:
     """Novae mode class, used to store states variables related to training and inference."""
 
-    zero_shot_clustering_attrs: list[str] = ["_clustering_zero", "_clusters_levels_zero"]
-    normal_clustering_attrs: list[str] = ["_clustering", "_clusters_levels"]
-    all_clustering_attrs: list[str] = normal_clustering_attrs + zero_shot_clustering_attrs
-
     def __init__(
         self,
         zero_shot: bool = False,
@@ -34,13 +30,3 @@ class Mode:
     def fit(self):
         self.zero_shot = False
         self.trained = False
-
-    ### Mode-specific attributes
-
-    @property
-    def clustering_attr(self):
-        return "_clustering_zero" if self.zero_shot else "_clustering"
-
-    @property
-    def clusters_levels_attr(self):
-        return "_clusters_levels_zero" if self.zero_shot else "_clusters_levels"

--- a/tests/test_prototypes.py
+++ b/tests/test_prototypes.py
@@ -6,9 +6,9 @@ from ._utils import adata_small as adata
 def test_init_prototypes():
     model = novae.Novae(adata, num_prototypes=20)
 
-    prototypes = model.swav_head.prototypes.data.clone()
+    prototypes = model.swav_head._prototypes.data.clone()
     model.init_prototypes(adata)
-    assert (model.swav_head.prototypes.data != prototypes).all()
+    assert (model.swav_head._prototypes.data != prototypes).all()
 
 
 def test_preserve_clustering():
@@ -16,11 +16,33 @@ def test_preserve_clustering():
     model.mode.trained = True
 
     clusters_levels = model.swav_head.clusters_levels
-    leiden_codes = model._leiden_prototypes()
+    leiden_codes = model.swav_head.leiden_clustering()
 
     model.save_pretrained("tests/test_proto_clustering")
 
     model2 = novae.Novae.from_pretrained("tests/test_proto_clustering")
 
     assert (model2.swav_head.clusters_levels == clusters_levels).all()
-    assert (model2._leiden_prototypes() == leiden_codes).all()
+    assert (model2.swav_head.leiden_clustering() == leiden_codes).all()
+
+
+def test_preserve_zero_shot_prototypes():
+    model = novae.Novae(adata, num_prototypes=50)
+    model.mode.trained = True
+
+    prototypes_before = model.swav_head._prototypes.data.clone()
+
+    model.compute_representations(adata, zero_shot=True)
+    prototypes = model.swav_head._prototypes.data.clone()
+    leiden_codes = model.swav_head.leiden_clustering(resolution=2)
+
+    assert (prototypes != prototypes_before).all(), "Prototypes should be updated after computing representations."
+
+    model.save_pretrained("tests/test_proto_zero_shot")
+    model2 = novae.Novae.from_pretrained("tests/test_proto_zero_shot")
+
+    prototypes_after = model2.swav_head._prototypes.data.clone()
+    assert (prototypes_after == prototypes).all(), "Prototypes should be preserved after re-loading a zero-shot model."
+
+    leiden_codes_after = model2.swav_head.leiden_clustering(resolution=2)
+    assert (leiden_codes_after == leiden_codes).all(), "Leiden should be preserved after re-loading a zero-shot model."

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -18,3 +18,32 @@ def test_get_reference():
 
     sid1 = adatas[1].obs[Keys.SLIDE_ID].iloc[0]
     assert get_reference(adatas, sid1)[0].obs[Keys.SLIDE_ID].iloc[0] == sid1
+
+
+def test_zero_shot_with_different_references():
+    adatas = novae.toy_dataset(compute_spatial_neighbors=True)
+
+    model = novae.Novae(adatas, num_prototypes=20)
+    model.mode.trained = True  # trick to avoid assert error in compute_representations
+
+    model.compute_representations(adatas, zero_shot=True, reference="all")
+    key_added = model.assign_domains(adatas[0], resolution=1)
+    domains_1 = adatas[0].obs[key_added].copy()
+
+    model.compute_representations(adatas, zero_shot=True, reference="all")
+    key_added = model.assign_domains(adatas[0], resolution=1)
+    domains_1_repro = adatas[0].obs[key_added].copy()
+
+    assert domains_1.equals(domains_1_repro), "Domains should be the same when using the same reference."
+
+    model.compute_representations(adatas, zero_shot=True, reference="largest")
+    key_added = model.assign_domains(adatas[0], resolution=1)
+    domains_2 = adatas[0].obs[key_added].copy()
+
+    model.compute_representations(adatas, zero_shot=True, reference=1)
+    key_added = model.assign_domains(adatas[0], resolution=1)
+    domains_3 = adatas[0].obs[key_added].copy()
+
+    assert not domains_1.equals(domains_2) and not domains_2.equals(domains_3) and not domains_1.equals(domains_3), (
+        "Domains should be different when using different references."
+    )


### PR DESCRIPTION
Computing representations in zero-shot mode updated the prototypes.

Until now, it has not preserved the updated prototype for future runs (e.g., if we save and reload the model and re-run compute_representation without zero_shot).

Now, it updates the prototypes, and the model acts as a trained model