### PR TITLE
Use `np.float64` in kmeans to improve zero_shot reproducibility

### DIFF
--- a/novae/module/swav.py
+++ b/novae/module/swav.py
@@ -190,9 +190,9 @@ class SwavHead(L.LightningModule):
         )
 
         kmeans = KMeans(n_clusters=self.num_prototypes, random_state=0, n_init="auto")
-        X = latent / (Nums.EPS + np.linalg.norm(latent, axis=1)[:, None])
+        X: np.ndarray = latent / (Nums.EPS + np.linalg.norm(latent, axis=1)[:, None])
 
-        kmeans_prototypes = kmeans.fit(X).cluster_centers_
+        kmeans_prototypes = kmeans.fit(X.astype(np.float64)).cluster_centers_
         kmeans_prototypes = kmeans_prototypes / (Nums.EPS + np.linalg.norm(kmeans_prototypes, axis=1)[:, None])
 
         self._prototypes = torch.nn.Parameter(torch.tensor(kmeans_prototypes))

--- a/novae/module/swav.py
+++ b/novae/module/swav.py
@@ -195,7 +195,9 @@ class SwavHead(L.LightningModule):
         kmeans_prototypes = kmeans.fit(X.astype(np.float64)).cluster_centers_
         kmeans_prototypes = kmeans_prototypes / (Nums.EPS + np.linalg.norm(kmeans_prototypes, axis=1)[:, None])
 
-        self._prototypes = torch.nn.Parameter(torch.tensor(kmeans_prototypes))
+        self._prototypes = torch.nn.Parameter(
+            torch.tensor(kmeans_prototypes, dtype=self._prototypes.dtype, device=self._prototypes.device)
+        )
 
         self.reset_clustering()
 

--- a/novae/plot/_spatial.py
+++ b/novae/plot/_spatial.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,6 +18,9 @@ from .._constants import Keys
 from ._utils import _get_default_cell_size, _subplots_per_slide, get_categorical_color_palette
 
 log = logging.getLogger(__name__)
+
+
+warnings.filterwarnings("ignore", message="Use `squidpy.pl.spatial_scatter` instead.", category=FutureWarning)
 
 
 def domains(


### PR DESCRIPTION
Improves #33, but reproducibility is still not 100% guaranteed (limitation of sklearn...), although the difference of the centroids of different runs is usually lower than 1e-16.

Note also that #60 also helps fix this issue: this will be available in `novae==1.1.0`, and a tutorial about this will be available

Minor: I also filtered a scanpy warning (can't switch to squidpy because squidpy is not in the novae deps).